### PR TITLE
chore: update repository references after transfer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,12 +14,12 @@
         "rev": "873898d084e41a4aaf7aa8685ed324044c96597e",
         "revCount": 490,
         "type": "git",
-        "url": "https://git.johnwilger.com/Slipstream/auto_review"
+        "url": "https://github.com/jwilger/auto_review.git"
       },
       "original": {
         "ref": "main",
         "type": "git",
-        "url": "https://git.johnwilger.com/Slipstream/auto_review"
+        "url": "https://github.com/jwilger/auto_review.git"
       }
     },
     "catppuccin": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "jwilger's nixos configuration";
 
   inputs = {
-    auto-review.url = "git+https://git.johnwilger.com/Slipstream/auto_review?ref=main";
+    auto-review.url = "git+https://github.com/jwilger/auto_review.git?ref=main";
 
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-small.url = "github:NixOS/nixpkgs/nixos-unstable-small";

--- a/modules/services/github-runner.nix
+++ b/modules/services/github-runner.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  githubOrgUrl = "https://github.com/slipstream-eng";
+  githubOrgUrl = "https://github.com/jwilger";
 
   # Docker-in-Docker, mirroring forgejo-runner-release's pattern in
   # forgejo-runner.nix: job containers (including service containers like
@@ -156,7 +156,7 @@ in
     };
   };
 
-  services.github-runners.slipstream-eng = {
+  services.github-runners.jwilger = {
     enable = true;
     name = "gregor";
     url = githubOrgUrl;
@@ -200,7 +200,7 @@ in
   # generated unit. Also wait for the DinD socket to actually be usable
   # before the runner starts accepting jobs, same pattern as
   # forgejo-runner-release's preStartExtra.
-  systemd.services.github-runner-slipstream-eng = {
+  systemd.services.github-runner-jwilger = {
     after = [ "github-runner-dind.service" ];
     wants = [ "github-runner-dind.service" ];
     preStart = lib.mkAfter ''
@@ -213,7 +213,7 @@ in
         sleep 1
       done
       if [ "$i" -eq 60 ]; then
-        echo "ERROR: ${dindSocket} is not ready for github-runner-slipstream-eng." >&2
+        echo "ERROR: ${dindSocket} is not ready for github-runner-jwilger." >&2
         exit 1
       fi
     '';


### PR DESCRIPTION
Updates post-transfer repository references and moves workflow runtime secret access
to the shared 1Password `Github Secrets` vault.

This only changes repositories that were part of the `slipstream-eng` migration
inventory.

Secret-loading changes:

- keep `OP_SERVICE_ACCOUNT_TOKEN` as the only GitHub Actions bootstrap secret
- load runtime values with `1password/load-secrets-action@v4`
- use `op://Github Secrets/...` references for cargo/Hex publish tokens,
  the GitHub release automation PAT, and the release signing SSH key
- remove Codecov and OpenAI/Anthropic/Claude token usage from CI
- use npm trusted publishing/OIDC instead of `NPM_TOKEN`
- keep built-in `GITHUB_TOKEN` usage unchanged

Runner migration:

- replace `self-hosted-gregor` with `ubuntu-latest` where the transferred
  personal-account repos no longer have an eligible shared runner
- add the repo-standard Determinate Systems Nix installer/cache actions before
  `nix develop` steps where needed

Verification run where applicable:

- `git diff --check`
- YAML parse check with Python `yaml.safe_load`
- `actionlint`

Notes:

- Historical generated changelog links were left alone.
- Forgejo product/runtime references were left alone unless they pointed at
  migrated source repositories.
- The remaining 1Password runtime secrets are populated: Cargo, Hex, GitHub
  release automation PAT, and release signing key.
- `GH_RELEASE_AUTOMATION_TOKEN` is a fine-grained PAT. Required repository
  permissions: Contents read/write, Pull requests read/write, Issues read/write
  for release-please repos, Metadata read-only. Do not grant Actions/Workflows
  unless release automation must edit workflow files; do not grant
  Administration unless protected tag rules block release tag creation.
- npm packages must be configured in npm as trusted publishers for their
  GitHub repository and publish workflow before tokenless npm publishing works.
