### PR TITLE
fix: stop nignite from misrouting reused-window link opens

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782681319,
-        "narHash": "sha256-8lNWvOfUDgvTh79hkQ8o9FDqcemR7GXcOUlFJP+N7Zk=",
+        "lastModified": 1783263742,
+        "narHash": "sha256-ZnF/UVrLEPMd98VRdQu5mRTFMC+L1VntnHc+xmqYUbk=",
         "ref": "main",
-        "rev": "873898d084e41a4aaf7aa8685ed324044c96597e",
-        "revCount": 490,
+        "rev": "f9c8b38e961551a61f602558f8d33a577a77650d",
+        "revCount": 497,
         "type": "git",
         "url": "https://github.com/jwilger/auto_review.git"
       },
@@ -27,11 +27,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1782648384,
-        "narHash": "sha256-OlHdAqdXasZk1U+Zf9n+ivqHL9kj/UD0DFO4yYTNBYc=",
+        "lastModified": 1783587400,
+        "narHash": "sha256-UEZ8LIavX5HFjtvSkj34ZBM30cWNpqJfXujm+B4rY1k=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "f2c7dd14ecce785c206a39466cbe227ff62e3803",
+        "rev": "b69e0494705aaf50cb2c6e0e005639b632044c6d",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782657028,
-        "narHash": "sha256-PHTCpYZCMzJYS3phhywqRAZphKVr2zjvlGYa+H20ZZ4=",
+        "lastModified": 1783550008,
+        "narHash": "sha256-qbbZUk9IG9dLNwCPwdPBs6I5clxwugRpP+1YU+GPK20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ad9aaae70c9aaab504127f926c0fa9cfbc2b365",
+        "rev": "f4d01c1d87c7c2ec909549165d5a8338f1bd3315",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1782592242,
-        "narHash": "sha256-kgINba6Ilpj3rdTi2BeKlQBs6ZxTdu3Gb49U5gDUVhg=",
+        "lastModified": 1783526091,
+        "narHash": "sha256-Zkkil0e8Wg5BcBmJkWJwBXlETefYQbYKw72xJUIBPLE=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "9e26dfe0fb8d61475b6f9e8d63477fe92509f1db",
+        "rev": "a24d4c0dce53fd8dbeb9ad20411e282c7b9875f1",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1781781064,
-        "narHash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
+        "lastModified": 1783522755,
+        "narHash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
+        "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
     },
     "nixpkgs-small": {
       "locked": {
-        "lastModified": 1782678633,
-        "narHash": "sha256-EfOItnWLyWTCyOFGaLLhvprA9k7axDaALfaZF4KwqVM=",
+        "lastModified": 1783564090,
+        "narHash": "sha256-ajlPoJbp28hK8Zgua3n+g4LuzGVGlKfs94jA2VVUa3Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa7c7aa95712c0d529bc944e473a370c5d72958",
+        "rev": "9ab0784f4b4b98a4f100d4cb2245d791cdccf70a",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782498288,
-        "narHash": "sha256-8/X3yyTXiE82b38n32ItbOqfWOVBl+gKa8fILyZfR4Q=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cac626ec5e3703e835f227687e88aa9e2f25701",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {
@@ -302,11 +302,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-8d2wCNWKnd86GzKZvbuqqlS+HqMrheXkvRf0qGJ/oA0=",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "lastModified": 1782918843,
+        "narHash": "sha256-mFP086y1bNA1g9AsY/pCue3H3W2R7ayroHyRbZrcMf0=",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1020805.89570f24e97e/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1025900.e8273b29fe13/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -315,11 +315,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -331,11 +331,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-inDx/w70OSJoJPqtKh0BrzAsbZZhpya7YgS43jHnhwg=",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "lastModified": 1783224372,
+        "narHash": "sha256-FGQ8TfSm9WviNE/fQAWsKs+y4GkX8fU4EScewpw54Y8=",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1022855.e73de5be04e0/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1027867.d407951447dc/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -363,11 +363,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1783114234,
-        "narHash": "sha256-vd3QlfiWEv/IHHr6gZZ2P80VPO+9qhDEJPBSmge4Erk=",
+        "lastModified": 1783596342,
+        "narHash": "sha256-lwInOD4VzBzLnBFUo87q4PfuNm0YXk8Y7kPbdS0GQcA=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "18b50824c375f825f4484b29c3ab9f8a0c6c2412",
+        "rev": "a3b00f660c070ff2fe10d15e2a46cae42ed10721",
         "type": "github"
       },
       "original": {
@@ -439,11 +439,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,6 @@
                   grep -F 'exec chrome-personal --new-window "$@"' ${hm.home.path}/bin/chrome-pick
                   grep -F 'exec chrome-work --new-window "$@"' ${hm.home.path}/bin/chrome-pick
                   grep -F 'niri msg action focus-window --id "$chrome_window_id"' ${hm.home.path}/bin/nignite
-                  grep -F -- '--new-tab "$@"' ${hm.home.path}/bin/nignite
                   grep -F 'exec chrome-pick "$@"' ${hm.home.path}/bin/nignite
                   touch $out
                 '';

--- a/modules/home/desktop/nignite.nix
+++ b/modules/home/desktop/nignite.nix
@@ -57,7 +57,15 @@ let
           || true
       )"
 
-      if [ -n "$focused_workspace_id" ]; then
+      # Chrome's own IPC for "open this URL" has no concept of "this specific
+      # window" - it always resolves to whatever window Chrome itself
+      # considers last-active, which can be on a different profile and a
+      # different workspace entirely, and it raises whatever it picks. So we
+      # don't ask Chrome to reuse a window for URLs: only a bare invocation
+      # (no URL) jumps to an existing window, since that has no wrong-window
+      # failure mode. Any URL always goes through chrome-pick, which only
+      # ever creates a new window on the current workspace.
+      if [ -n "$focused_workspace_id" ] && [ "$#" -eq 0 ]; then
         chrome_window_id="$(
           niri msg -j windows 2>/dev/null \
             | jq -er --argjson workspace_id "$focused_workspace_id" '
@@ -75,12 +83,7 @@ let
 
         if [ -n "$chrome_window_id" ]; then
           niri msg action focus-window --id "$chrome_window_id" >/dev/null 2>&1 || true
-
-          if [ "$#" -eq 0 ]; then
-            exit 0
-          fi
-
-          exec ${browserExe} --new-tab "$@"
+          exit 0
         fi
       fi
 


### PR DESCRIPTION
## Summary
- Chrome's command-line/IPC interface has no way to target a specific window when opening a URL - it always resolves to whatever window Chrome itself considers last-active, regardless of profile or workspace, and raises it. `nignite`'s window-reuse fallback relied on `--new-tab` (not a real Chrome flag) to steer this, so a clicked link could silently reuse a Chrome window on a different workspace and pull focus there with it.
- A synthetic-keystroke-injection fix (`wtype`) was tried and reverted after live testing showed a real focus-timing race that could type arbitrary URL text into an unrelated window (e.g. a terminal prompt) - unsafe.
- `nignite` now only reuses an existing window for a bare invocation with no URL (no wrong-window failure mode possible there). Any URL always routes through `chrome-pick`, which only ever opens a new window on the current workspace - correct and safe every time, at the cost of not reusing an existing window for links.
- Updated the `chrome-profile-launching` flake check to match the new script content.
- Includes routine `flake.lock` input bumps picked up incidentally while validating this fix.

## Test plan
- [x] `nix build .#checks.x86_64-linux.chrome-profile-launching` passes
- [x] Live-tested on gregor: focused a Chrome window on one workspace, invoked `nignite` from another - old behavior jumped workspace and typed into the wrong window; new behavior leaves focus untouched and opens `chrome-pick` on the current workspace
- [ ] `sudo nixos-rebuild switch --flake .#gregor` to apply, then click a link in kitty to confirm the picker opens on the current workspace with no jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvbqYknJmdC7gg2DCdetee