### PR TITLE
fix: remove invalid Mergify condition attributes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,9 +8,6 @@ queue_rules:
       - "-conflict"
       - "#approved-reviews-by >= 1"
       - "#changes-requested-reviews-by = 0"
-      - "github-review-approved"
-      - "github-require-last-push-approval"
-      - "github-code-owner-review-satisfied"
     merge_conditions: *default_conditions
 
 merge_protections_settings:


### PR DESCRIPTION
## Summary
- `.mergify.yml`'s shared condition list includes three attribute names as condition strings: `github-review-approved`, `github-require-last-push-approval`, `github-code-owner-review-satisfied`. Mergify rejects all three: "evaluated internally by Mergify and cannot be used in conditions."
- This has been failing the `Mergify Merge Queue` check with a real `failure` conclusion on every PR (confirmed on PR #7). PR #6 still merged because the separate `Mergify Merge Protections` check only evaluates the remaining valid conditions and doesn't depend on these three.
- Removes just those three lines from the shared `&default_conditions` anchor. The actual gate - `#approved-reviews-by >= 1` and `#changes-requested-reviews-by = 0` - is unchanged.

## Test plan
- [ ] Confirm the `Mergify Merge Queue` check passes (no longer shows the invalid-condition failure) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvbqYknJmdC7gg2DCdetee